### PR TITLE
refactor redundant code

### DIFF
--- a/EWSEmailAttachmentSaver.ps1
+++ b/EWSEmailAttachmentSaver.ps1
@@ -108,14 +108,10 @@ Function FindTargetEmail($subject){
 					LogWrite "$workstationreportfolder not found.."
 					LogWrite "Creating it now.."
 					New-Item -ItemType Directory $workstationreportfolder | Out-Null
-					LogWrite "$attachmentname saved to $workstationreportfolder"
-					$file = New-Object System.IO.FileStream(($workstationreportfolder + $attachmentname), [System.IO.FileMode]::Create)
-					$file.Write($attachment.Content, 0, $attachment.Content.Length)
-				} else {
-					LogWrite "$attachmentname saved to $workstationreportfolder"
-					$file = New-Object System.IO.FileStream(($workstationreportfolder + $attachmentname), [System.IO.FileMode]::Create)
-					$file.Write($attachment.Content, 0, $attachment.Content.Length)
 				}
+				LogWrite "$attachmentname saved to $workstationreportfolder"
+				$file = New-Object System.IO.FileStream(($workstationreportfolder + $attachmentname), [System.IO.FileMode]::Create)
+				$file.Write($attachment.Content, 0, $attachment.Content.Length)
 				$file.Close()
 			} elseif ($attachmentname -like '*Server*'){
 				$serverreportfolder = $reportroot + "Servers\" + $fileyear + "\" + $filemonth + "\"
@@ -123,14 +119,10 @@ Function FindTargetEmail($subject){
 					LogWrite "$serverreportfolder not found.."
 					LogWrite "Creating it now.."
 					New-Item -ItemType Directory $serverreportfolder | Out-Null
-					LogWrite "$attachmentname saved to $serverreportfolder"
-					$file = New-Object System.IO.FileStream(($serverreportfolder + $attachmentname), [System.IO.FileMode]::Create)
-					$file.Write($attachment.Content, 0, $attachment.Content.Length)
-				} else {
-					LogWrite "$attachmentname saved to $serverreportfolder"
-					$file = New-Object System.IO.FileStream(($serverreportfolder + $attachmentname), [System.IO.FileMode]::Create)
-					$file.Write($attachment.Content, 0, $attachment.Content.Length)
 				}
+				LogWrite "$attachmentname saved to $serverreportfolder"	
+				$file = New-Object System.IO.FileStream(($serverreportfolder + $attachmentname), [System.IO.FileMode]::Create)	
+				$file.Write($attachment.Content, 0, $attachment.Content.Length)
 				$file.Close()
 			} else {}
 		}


### PR DESCRIPTION
the saving of the attachment will happen regardless of the destination folder exist or not, since there is already a check for the existence of the destination folder.

Current logic:
if destination folder doesnt exist, create destination folder and save attachment to destination folder.
else save the attachment to destination folder.

Change:
if destination folder doesnt exist, create destination folder.
save the attachment to destination folder.